### PR TITLE
log in href

### DIFF
--- a/texgpt/webview-ui/src/pages/Auth/AuthPage.css
+++ b/texgpt/webview-ui/src/pages/Auth/AuthPage.css
@@ -29,6 +29,17 @@
   font-size: 11px;
 }
 
+.auth-link {
+  color: var(--vscode-textLink-foreground);
+  text-decoration: none;
+  cursor: pointer;
+}
+
+.auth-link:hover {
+  color: var(--vscode-textLink-activeForeground);
+  text-decoration: underline;
+}
+
 .auth-header,
 .auth-form,
 .saml-auth {

--- a/texgpt/webview-ui/src/pages/Auth/AuthPage.jsx
+++ b/texgpt/webview-ui/src/pages/Auth/AuthPage.jsx
@@ -32,7 +32,21 @@ const AuthPage = () => {
           {isSignup ? <SignupForm /> : <LoginForm />}
           <div className="auth-toggle">
             <p>
-              Already have an account? Log in
+              {isSignup ? (
+                <>
+                  Already have an account?{' '}
+                  <a href="#" onClick={(e) => { e.preventDefault(); setIsSignup(false); }} className="auth-link">
+                    Log in
+                  </a>
+                </>
+              ) : (
+                <>
+                  Don't have an account?{' '}
+                  <a href="#" onClick={(e) => { e.preventDefault(); setIsSignup(true); }} className="auth-link">
+                    Sign up
+                  </a>
+                </>
+              )}
             </p>
           </div>
         </div>


### PR DESCRIPTION
### TL;DR

Added toggle functionality between login and signup forms with styled links.

### What changed?

- Added CSS styles for authentication links with proper hover effects using VSCode theme variables
- Updated the auth toggle section to conditionally render different text based on the current mode (login or signup)
- Implemented clickable links that switch between login and signup forms when clicked
- Added proper event handling to prevent default link behavior

### How to test?

1. Open the authentication page
2. Verify that "Log in" link appears when on the signup form
3. Click the "Log in" link and confirm it switches to the login form
4. Verify that "Sign up" link appears when on the login form
5. Click the "Sign up" link and confirm it switches to the signup form
6. Check that links have proper styling and hover effects

### Why make this change?

This change improves user experience by providing a clear and intuitive way to switch between login and signup forms. Previously, the text suggested users could toggle between forms but didn't provide the actual functionality. The styled links now make it obvious that users can click to switch modes, following standard web conventions.