### PR TITLE
add watch to start-dev

### DIFF
--- a/start-dev.sh
+++ b/start-dev.sh
@@ -30,6 +30,7 @@ tmux send-keys 'python app.py' C-m
 tmux select-pane -t 2
 tmux send-keys 'cd texgpt' C-m
 tmux send-keys 'npm install' C-m
+tmux send-keys 'npm run build:webview && npm run dev:webview' C-m
 
 # Attach to the session
 tmux attach-session -t ra-prod


### PR DESCRIPTION
### TL;DR

Added command to automatically build and run the webview in development mode when starting the development environment.

### What changed?

Added a new `tmux` command in the `start-dev.sh` script that runs `npm run build:webview && npm run dev:webview` after the npm install step in the texgpt directory.

### How to test?

1. Run `./start-dev.sh` to start the development environment
2. Verify that the webview builds and starts automatically in the texgpt pane
3. Confirm that you no longer need to manually run the webview build and dev commands

### Why make this change?

To streamline the development workflow by automating the webview build and run process. This eliminates a manual step that developers previously had to perform each time they started the development environment.